### PR TITLE
Implement immediate sensor updates with a short initial delay

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,30 +145,51 @@ const VitalsWidget = GObject.registerClass(
       });
     }
 
+    private _performSensorUpdate(type: VitalType): void {
+      const vital = this._vitals.get(type);
+      const sensor = this._sensors.get(type);
+
+      if (this._vitals.size > 0 && vital && vital.visible && sensor) {
+        sensor
+          .getValue()
+          .then((value: number) => {
+            vital.update(value);
+          })
+          .catch((err: any) => {
+            console.error(`[VitalsWidget] Error getting ${type} value:`, err);
+            vital.update(0);
+          });
+      }
+    }
+
+    private _startRecurringTimer(type: VitalType, interval: number): number {
+      const id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, interval, () => {
+          const vital = this._vitals.get(type);
+          const sensor = this._sensors.get(type);
+
+          if (this._vitals.size > 0 && vital && vital.visible && sensor) {
+            this._performSensorUpdate(type);
+            return GLib.SOURCE_CONTINUE;
+          }
+          return GLib.SOURCE_REMOVE;
+        }
+      );
+      this._intervals.set(type, id);
+      return id;
+    }
+
     private _restartVitalTimer(type: VitalType): void {
       const oldId = this._intervals.get(type);
       if (oldId) GLib.source_remove(oldId);
 
       const interval = this._settings.get_int(`${type}-update-interval`);
-      const id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, interval, () => {
-        const vital = this._vitals.get(type);
-        const sensor = this._sensors.get(type);
 
-        if (this._vitals.size > 0 && vital && vital.visible && sensor) {
-          sensor
-            .getValue()
-            .then((value: number) => {
-              vital.update(value);
-            })
-            .catch((err: any) => {
-              console.error(`[VitalsWidget] Error getting ${type} value:`, err);
-              vital.update(0);
-            });
-          return GLib.SOURCE_CONTINUE;
-        }
+      const initialDelay = 500;
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, initialDelay, () => {
+        this._performSensorUpdate(type);
+        this._startRecurringTimer(type, interval);
         return GLib.SOURCE_REMOVE;
       });
-      this._intervals.set(type, id);
     }
 
     private _clearTimers(): void {
@@ -191,7 +212,7 @@ const VitalsWidget = GObject.registerClass(
 
       super.destroy();
     }
-  }
+  },
 );
 
 export default class VitalsWidgetExtension extends Extension {


### PR DESCRIPTION
Implement immediate sensor updates with a short initial delay, then recurring timer as configured

- this avoids the initial long delay of 60 seconds for Storage